### PR TITLE
Create `EventPollingExecutorScheduler` abstraction

### DIFF
--- a/core/src/main/scala/epollcat/unsafe/EpollRuntime.scala
+++ b/core/src/main/scala/epollcat/unsafe/EpollRuntime.scala
@@ -32,8 +32,7 @@ object EpollRuntime {
   }
 
   def defaultExecutionContextScheduler(): (ExecutionContext with Scheduler, () => Unit) = {
-    val ecScheduler = EpollExecutorScheduler()
-    (ecScheduler, () => ecScheduler.close())
+    EventPollingExecutorScheduler(64)
   }
 
   def global: IORuntime = {

--- a/core/src/main/scala/epollcat/unsafe/EventPollingExecutorScheduler.scala
+++ b/core/src/main/scala/epollcat/unsafe/EventPollingExecutorScheduler.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package epollcat.unsafe
+
+import cats.effect.unsafe.PollingExecutorScheduler
+
+private[epollcat] abstract class EventPollingExecutorScheduler
+    extends PollingExecutorScheduler {
+
+  def monitor(fd: Int, reads: Boolean, writes: Boolean)(cb: EventNotificationCallback): Runnable
+
+}
+
+private[epollcat] trait EventNotificationCallback {
+  protected def notifyEvents(readReady: Boolean, writeReady: Boolean): Unit
+}
+
+private[epollcat] object EventPollingExecutorScheduler {
+
+  def apply(maxEvents: Int): (EventPollingExecutorScheduler, () => Unit) = {
+    EpollExecutorScheduler(maxEvents)
+  }
+
+}

--- a/tests/native/src/test/scala/epollcat/EventPollingExecutorSchedulerSuite.scala
+++ b/tests/native/src/test/scala/epollcat/EventPollingExecutorSchedulerSuite.scala
@@ -17,15 +17,15 @@
 package epollcat
 
 import cats.effect.IO
-import epollcat.unsafe.EpollExecutorScheduler
+import epollcat.unsafe.EventPollingExecutorScheduler
 import epollcat.unsafe.EpollRuntime
 
 import scala.concurrent.duration._
 
-class EpollExecutorSchedulerSuite extends EpollcatSuite {
+class EventPollingExecutorSchedulerSuite extends EpollcatSuite {
 
   test("installs globally") {
-    assert(EpollRuntime.global.compute.isInstanceOf[EpollExecutorScheduler])
+    assert(EpollRuntime.global.compute.isInstanceOf[EventPollingExecutorScheduler])
   }
 
   test("ceding") {


### PR DESCRIPTION
So we can have multiple implementations:
- the existing `EpollExecutorScheduler`
- a forthcoming `KqueueExecutorScheduler` for https://github.com/armanbilge/epollcat/issues/2