### PR TITLE
Make `IOServerSocketChannel#accept` cancelable

### DIFF
--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
@@ -54,7 +54,7 @@ final class EpollAsyncServerSocketChannel private (fd: Int)
     }
   }
 
-  def close(): Unit = {
+  def close(): Unit = if (isOpen()) {
     _isOpen = false
     unmonitor.run()
     if (posix.unistd.close(fd) == -1)

--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
@@ -67,7 +67,7 @@ final class EpollAsyncSocketChannel private (fd: Int)
     }
   }
 
-  def close(): Unit = {
+  def close(): Unit = if (isOpen()) {
     _isOpen = false
     unmonitor.run()
     if (posix.unistd.close(fd) == -1)

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -33,7 +33,6 @@ import java.nio.channels.AsynchronousSocketChannel
 import java.nio.channels.ClosedChannelException
 import java.nio.channels.CompletionHandler
 import java.nio.charset.StandardCharsets
-import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 
 class TcpSuite extends EpollcatSuite {
@@ -287,8 +286,7 @@ class TcpSuite extends EpollcatSuite {
       .evalTap(_.bind(new InetSocketAddress(0)))
       .flatMap(_.accept)
       .use_
-      .timeout(100.millis)
-      .intercept[TimeoutException]
+      .timeoutTo(100.millis, IO.unit)
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/armanbilge/epollcat/issues/21. I think :)

This was more of a problem with our tests than the actual implementation. But it definitely warrants discussion.

The reason for the hang was that Cats Effect will never "fire-and-forget" by default: if there is an error, it will cancel other running fibers (aka green threads) and wait for their cancellation. If an action is not cancelable, then it will wait until that action either completes or errors before canceling that fiber.

Since `accept` was not cancelable if fell into this trap.