### PR TITLE
Update to munit-cats-effect 2.0-17d21ae-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ ThisBuild / crossScalaVersions := Seq("3.1.3", "2.12.16", "2.13.8")
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 
 val catsEffectVersion = "3.4-519e5ce-SNAPSHOT"
-val munitCEVersion = "2.0-4e051ab-SNAPSHOT"
+val munitCEVersion = "2.0-17d21ae-SNAPSHOT"
 
 lazy val root = tlCrossRootProject.aggregate(core, tests)
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,7 @@ lazy val core = project
   .settings(
     name := "epollcat",
     libraryDependencies ++= Seq(
-      "com.armanbilge" %%% "cats-effect" % catsEffectVersion,
-      "com.armanbilge" %%% "munit-cats-effect" % munitCEVersion % Test
+      "com.armanbilge" %%% "cats-effect" % catsEffectVersion
     )
   )
 
@@ -37,7 +36,7 @@ lazy val tests = crossProject(JVMPlatform, NativePlatform)
   )
   .jvmSettings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "munit-cats-effect" % "2.0.0-M1" % Test
+      "org.typelevel" %%% "munit-cats-effect" % "2.0-f307b51-SNAPSHOT" % Test
     )
   )
 

--- a/tests/native/src/test/scala/epollcat/EpollcatSuite.scala
+++ b/tests/native/src/test/scala/epollcat/EpollcatSuite.scala
@@ -20,5 +20,5 @@ import epollcat.unsafe.EpollRuntime
 import munit.CatsEffectSuite
 
 trait EpollcatSuite extends CatsEffectSuite {
-  override lazy val munitIoRuntime = EpollRuntime.global
+  override def munitIORuntime = EpollRuntime.global
 }

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -37,6 +37,8 @@ import scala.concurrent.duration._
 
 class TcpSuite extends EpollcatSuite {
 
+  override def munitIOTimeout = 10.seconds
+
   def toHandler[A](cb: Either[Throwable, A] => Unit): CompletionHandler[A, Any] =
     new CompletionHandler[A, Any] {
       def completed(result: A, attachment: Any): Unit = cb(Right(result))

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -37,7 +37,7 @@ import scala.concurrent.duration._
 
 class TcpSuite extends EpollcatSuite {
 
-  override def munitIOTimeout = 10.seconds
+  override def munitIOTimeout = 20.seconds
 
   def toHandler[A](cb: Either[Throwable, A] => Unit): CompletionHandler[A, Any] =
     new CompletionHandler[A, Any] {


### PR DESCRIPTION
This update brings support for test timeouts.

I gave it a try with the 2-minute `connect` hang and it appears to work.