### PR TITLE
Fix #39: getaddrinfo numeric error codes are now translated

### DIFF
--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
@@ -85,8 +85,10 @@ final class EpollAsyncServerSocketChannel private (fd: Int)
           hints,
           addrinfo
         )
-      if (rtn != 0)
-        throw new IOException(s"getaddrinfo: ${rtn}")
+      if (rtn != 0) {
+        val gaiMsg = SocketHelpers.getGaiErrorMessage(rtn, addr)
+        throw new IOException(s"getaddrinfo: ${gaiMsg}")
+      }
     }
 
     val bindRet = posix.sys.socket.bind(fd, (!addrinfo).ai_addr, (!addrinfo).ai_addrlen)

--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
@@ -86,7 +86,7 @@ final class EpollAsyncServerSocketChannel private (fd: Int)
           addrinfo
         )
       if (rtn != 0) {
-        val gaiMsg = SocketHelpers.getGaiErrorMessage(rtn, addr)
+        val gaiMsg = SocketHelpers.getGaiErrorMessage(rtn)
         throw new IOException(s"getaddrinfo: ${gaiMsg}")
       }
     }

--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
@@ -196,7 +196,8 @@ final class EpollAsyncSocketChannel private (fd: Int)
           addrinfo
         )
       if (rtn != 0) {
-        handler.failed(new IOException(s"getaddrinfo: $rtn"), attachment)
+        val gaiMsg = SocketHelpers.getGaiErrorMessage(rtn, addr)
+        handler.failed(new IOException(s"getaddrinfo: ${gaiMsg}"), attachment)
         false
       } else true
     }

--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
@@ -196,7 +196,7 @@ final class EpollAsyncSocketChannel private (fd: Int)
           addrinfo
         )
       if (rtn != 0) {
-        val gaiMsg = SocketHelpers.getGaiErrorMessage(rtn, addr)
+        val gaiMsg = SocketHelpers.getGaiErrorMessage(rtn)
         handler.failed(new IOException(s"getaddrinfo: ${gaiMsg}"), attachment)
         false
       } else true

--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer
 import java.nio.channels.AsynchronousSocketChannel
 import java.nio.channels.ClosedChannelException
 import java.nio.channels.CompletionHandler
+import java.nio.channels.UnsupportedAddressTypeException
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
@@ -195,11 +196,18 @@ final class EpollAsyncSocketChannel private (fd: Int)
           hints,
           addrinfo
         )
-      if (rtn != 0) {
-        val gaiMsg = SocketHelpers.getGaiErrorMessage(rtn)
-        handler.failed(new IOException(s"getaddrinfo: ${gaiMsg}"), attachment)
+      if (rtn == 0) {
+        true
+      } else {
+        val ex = if (rtn == posix.netdb.EAI_FAMILY) {
+          new UnsupportedAddressTypeException()
+        } else {
+          val msg = s"getaddrinfo: ${SocketHelpers.getGaiErrorMessage(rtn)}"
+          new IOException(msg)
+        }
+        handler.failed(ex, attachment)
         false
-      } else true
+      }
     }
 
     if (!continue)

--- a/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
+++ b/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
@@ -116,7 +116,7 @@ private[ch] object SocketHelpers {
 
   // Return text translation of getaddrinfo (gai) error code.
   def getGaiErrorMessage(gaiErrorCode: CInt): String = {
-    s"${fromCString(posix.netdb.gai_strerror(gaiErrorCode))}"
+    fromCString(posix.netdb.gai_strerror(gaiErrorCode))
   }
 
 }

--- a/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
+++ b/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
@@ -114,29 +114,9 @@ private[ch] object SocketHelpers {
     new InetSocketAddress(inetAddr, port)
   }
 
-  /* Return text translation of getaddrinfo (gai) error code.
-   * Since this is predominantly executed whilst on an error path,
-   * be particularly picky about checking for nulls. Prior code on the path
-   * should have reported or thrown NPE on nulls. But here we are, probably
-   * on an error path with an indeterminate world.
-   *
-   * The extra 'address' and 'port' information is given to possibly
-   * provide clues to reduce defect removal cycles.
-   */
-  def getGaiErrorMessage(gaiErrorCode: CInt, addr: InetSocketAddress): String = {
-    java.util.Objects.requireNonNull(addr, "unexpected null InetSocketAddress")
-
-    val gaiMsg = fromCString(posix.netdb.gai_strerror(gaiErrorCode))
-
-    val adr = {
-      val aga = addr.getAddress()
-      if (aga == null) "null" // No requireNonNull, salvage port info
-      else aga.getHostAddress()
-    }
-
-    val port = addr.getPort.toString
-
-    s"${gaiMsg} address: ${adr}  port: ${port}"
+  // Return text translation of getaddrinfo (gai) error code.
+  def getGaiErrorMessage(gaiErrorCode: CInt): String = {
+    s"${fromCString(posix.netdb.gai_strerror(gaiErrorCode))}"
   }
 
 }

--- a/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
+++ b/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
@@ -114,4 +114,29 @@ private[ch] object SocketHelpers {
     new InetSocketAddress(inetAddr, port)
   }
 
+  /* Return text translation of getaddrinfo (gai) error code.
+   * Since this is predominantly executed whilst on an error path,
+   * be particularly picky about checking for nulls. Prior code on the path
+   * should have reported or thrown NPE on nulls. But here we are, probably
+   * on an error path with an indeterminate world.
+   *
+   * The extra 'address' and 'port' information is given to possibly
+   * provide clues to reduce defect removal cycles.
+   */
+  def getGaiErrorMessage(gaiErrorCode: CInt, addr: InetSocketAddress): String = {
+    java.util.Objects.requireNonNull(addr, "unexpected null InetSocketAddress")
+
+    val gaiMsg = fromCString(posix.netdb.gai_strerror(gaiErrorCode))
+
+    val adr = {
+      val aga = addr.getAddress()
+      if (aga == null) "null" // No requireNonNull, salvage port info
+      else aga.getHostAddress()
+    }
+
+    val port = addr.getPort.toString
+
+    s"${gaiMsg} address: ${adr}  port: ${port}"
+  }
+
 }

--- a/core/src/main/scala/java/nio/channels/UnsupportedAddressTypeException.scala
+++ b/core/src/main/scala/java/nio/channels/UnsupportedAddressTypeException.scala
@@ -16,4 +16,4 @@
 
 package java.nio.channels
 
-class  UnsupportedAddressTypeException extends IllegalArgumentException
+class UnsupportedAddressTypeException extends IllegalArgumentException

--- a/core/src/main/scala/java/nio/channels/UnsupportedAddressTypeException.scala
+++ b/core/src/main/scala/java/nio/channels/UnsupportedAddressTypeException.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package java.nio.channels
+
+class  UnsupportedAddressTypeException extends IllegalArgumentException

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -182,7 +182,15 @@ class TcpSuite extends EpollcatSuite {
           _ <- ch.bind(new InetSocketAddress("240.0.0.1", 0))
         } yield ()
       }
-      .interceptMessage[BindException]("Cannot assign requested address")
+      .interceptMessage[BindException] {
+        val osName = System.getProperty("os.name", "unknown").toLowerCase
+        if (osName.startsWith("linux"))
+          "Cannot assign requested address"
+        else if (osName.startsWith("mac"))
+          "Can't assign requested address"
+        else
+          "unknown operating system"
+      }
   }
 
   test("ClosedChannelException") {


### PR DESCRIPTION
Numeric error codes returned from `getaddrinfo` are now translated to text.
Fixes #39.

Previously:
```
==> X epollcat.TcpSuite.LeeT gai error msg 0.01s
java.io.IOException: getaddrinfo: -9
```
After this PR:
```
==> X epollcat.TcpSuite.LeeT gai error msg 0.01s
java.io.IOException: getaddrinfo:
  Address family for hostname not supported address: 240.0.0.1  port: 80
```

Most developers will never see these messages, but those who do will
appreciate the time savings.