### PR TITLE
Store the remote address eagerly

### DIFF
--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
@@ -40,8 +40,10 @@ import scala.scalanative.posix.netdbOps._
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 
-final class EpollAsyncSocketChannel private (fd: Int, private var remoteAddress: SocketAddress)
-    extends AsynchronousSocketChannel(null)
+final class EpollAsyncSocketChannel private (
+    fd: Int,
+    private[this] var remoteAddress: SocketAddress
+) extends AsynchronousSocketChannel(null)
     with EventNotificationCallback {
 
   private var unmonitor: Runnable = null

--- a/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
+++ b/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
@@ -106,6 +106,12 @@ private[ch] object SocketHelpers {
         .socket
         .getsockname(fd, addr.asInstanceOf[Ptr[posix.sys.socket.sockaddr]], len) == -1)
       throw new IOException(s"getsockname: ${errno.errno}")
+    toInetSocketAddress(addr)
+  }
+
+  def toInetSocketAddress(
+      addr: Ptr[posix.netinet.in.sockaddr_in]
+  ): InetSocketAddress = {
     val port = posix.arpa.inet.htons(addr.sin_port).toInt
     val addrBytes = addr.sin_addr.at1.asInstanceOf[Ptr[Byte]]
     val inetAddr = InetAddress.getByAddress(

--- a/core/src/main/scala/epollcat/internal/ch/socket.scala
+++ b/core/src/main/scala/epollcat/internal/ch/socket.scala
@@ -18,14 +18,14 @@ package epollcat.internal.ch
 
 import scala.annotation.nowarn
 import scala.scalanative.unsafe._
+import scala.scalanative.posix.sys.socket._
 
 @extern
 @nowarn
 private[ch] object socket {
   final val SOCK_NONBLOCK = 2048 // only in Linux and FreeBSD, but not macOS
 
-  def accept(sockfd: CInt, addr: Ptr[Byte], addrlen: Ptr[Byte]): CInt = extern
-
   // only supported on Linux and FreeBSD, but not macOS
-  def accept4(sockfd: CInt, addr: Ptr[Byte], addrlen: Ptr[Byte], flags: CInt): CInt = extern
+  def accept4(sockfd: CInt, addr: Ptr[sockaddr], addrlen: Ptr[socklen_t], flags: CInt): CInt =
+    extern
 }

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -175,7 +175,7 @@ class TcpSuite extends EpollcatSuite {
     }
   }
 
-  test("local and remote addresses".only) {
+  test("local and remote addresses") {
     IOServerSocketChannel.open.evalTap(_.bind(new InetSocketAddress("127.0.0.1", 0))).use {
       server =>
         IOSocketChannel.open.use { clientCh =>

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -175,13 +175,15 @@ class TcpSuite extends EpollcatSuite {
     }
   }
 
-  test("local and remote addresses") {
+  test("local and remote addresses".only) {
     IOServerSocketChannel.open.evalTap(_.bind(new InetSocketAddress("127.0.0.1", 0))).use {
       server =>
         IOSocketChannel.open.use { clientCh =>
           server.localAddress.flatMap(clientCh.connect(_)) *>
             server.accept.use { serverCh =>
               for {
+                _ <- serverCh.shutdownOutput
+                _ <- clientCh.shutdownOutput
                 serverLocal <- serverCh.localAddress
                 serverRemote <- serverCh.remoteAddress
                 clientLocal <- clientCh.localAddress


### PR DESCRIPTION
This bug was uncovered by a test in fs2-io.
https://github.com/typelevel/fs2/blob/3a291dbf844fc4dfc0ecb66a3d399dd46d5e33e7/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala#L138-L162

In short: after `shutdownOutput` has been called, attempting to retrieve the remote address with `getpeername` returns errno 107 `ENOTCONN` "Transport endpoint is not connected".

This is inconsistent with the JDK behavior, which appears to be storing the remote address eagerly so that it can be returned even after the connection has closed. Hence, we do the same. 