### PR TITLE
Make global `EpollRuntime` independent of `IORuntime`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p target .js/target .jvm/target .native/target tests/jvm/target core/target tests/native/target project/target
+        run: mkdir -p target .js/target .jvm/target .native/target tests/jvm/target core/target example/target tests/native/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar target .js/target .jvm/target .native/target tests/jvm/target core/target tests/native/target project/target
+        run: tar cf targets.tar target .js/target .jvm/target .native/target tests/jvm/target core/target example/target tests/native/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
         if: matrix.java == 'temurin@17'
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' doc
 
+      - name: Run the example
+        if: matrix.project == 'rootNative'
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' example/run
+
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         run: mkdir -p target .js/target .jvm/target .native/target tests/jvm/target core/target example/target tests/native/target project/target

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ ThisBuild / githubWorkflowBuildMatrixExclusions ++= {
 val catsEffectVersion = "3.3.14-1-5d11fe9"
 val munitCEVersion = "2.0-5e03bfc"
 
-lazy val root = tlCrossRootProject.aggregate(core, tests)
+lazy val root = tlCrossRootProject.aggregate(core, tests, example)
 
 lazy val core = project
   .in(file("core"))
@@ -39,6 +39,12 @@ lazy val tests = crossProject(JVMPlatform, NativePlatform)
   .nativeConfigure(_.dependsOn(core))
   .settings(
     libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-effect" % catsEffectVersion,
       "org.typelevel" %%% "munit-cats-effect" % munitCEVersion % Test
     )
   )
+
+lazy val example = project
+  .in(file("example"))
+  .enablePlugins(ScalaNativePlugin, NoPublishPlugin)
+  .dependsOn(tests.native)

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,14 @@ ThisBuild / githubWorkflowBuildMatrixExclusions ++= {
   } yield MatrixExclude(Map("scala" -> scala, "os" -> os))
 }
 
+ThisBuild / githubWorkflowBuild ++= Seq(
+  WorkflowStep.Sbt(
+    List("example/run"),
+    name = Some("Run the example"),
+    cond = Some("matrix.project == 'rootNative'")
+  )
+)
+
 val catsEffectVersion = "3.3.14-1-5d11fe9"
 val munitCEVersion = "2.0-5e03bfc"
 

--- a/core/src/main/scala/epollcat/EpollApp.scala
+++ b/core/src/main/scala/epollcat/EpollApp.scala
@@ -22,7 +22,20 @@ import epollcat.unsafe.EpollRuntime
 
 trait EpollApp extends IOApp {
 
-  override final lazy val runtime: IORuntime = EpollRuntime(runtimeConfig)
+  override final lazy val runtime: IORuntime = {
+    val installed = EpollRuntime installGlobal {
+      EpollRuntime(runtimeConfig)
+    }
+
+    if (!installed) {
+      System
+        .err
+        .println(
+          "WARNING: Epollcat global runtime already initialized; custom configurations will be ignored")
+    }
+
+    EpollRuntime.global
+  }
 
 }
 

--- a/core/src/main/scala/epollcat/unsafe/EpollRuntime.scala
+++ b/core/src/main/scala/epollcat/unsafe/EpollRuntime.scala
@@ -35,9 +35,25 @@ object EpollRuntime {
     EventPollingExecutorScheduler(64)
   }
 
-  def global: IORuntime = {
-    IORuntime.installGlobal(EpollRuntime())
-    IORuntime.global
+  private[this] var _global: IORuntime = null
+
+  private[epollcat] def installGlobal(global: => IORuntime): Boolean = {
+    if (_global == null) {
+      _global = global
+      true
+    } else {
+      false
+    }
+  }
+
+  lazy val global: IORuntime = {
+    if (_global == null) {
+      installGlobal {
+        EpollRuntime()
+      }
+    }
+
+    _global
   }
 
 }

--- a/example/src/main/scala/ExampleApp.scala
+++ b/example/src/main/scala/ExampleApp.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package epollcat
+
+import cats.effect.IO
+
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
+object ExampleApp extends EpollApp.Simple {
+
+  def decode(bb: ByteBuffer): String =
+    StandardCharsets.UTF_8.decode(bb).toString()
+
+  override def run: IO[Unit] = {
+    val address = new InetSocketAddress(InetAddress.getByName("postman-echo.com"), 80)
+    val bytes =
+      """|GET /get HTTP/1.1
+         |Host: postman-echo.com
+         |
+         |""".stripMargin.getBytes()
+
+    IOSocketChannel.open.use { ch =>
+      for {
+        _ <- ch.connect(address)
+        _ <- ch.write(ByteBuffer.wrap(bytes))
+        bb <- IO(ByteBuffer.allocate(1024))
+        _ <- ch.read(bb)
+        res <- IO(bb.position(0)) *> IO(decode(bb))
+        _ <- IO.println(res)
+      } yield ()
+    }
+  }
+
+}

--- a/tests/shared/src/main/scala/epollcat/IOChannels.scala
+++ b/tests/shared/src/main/scala/epollcat/IOChannels.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package epollcat
+
+import cats.effect.IO
+import cats.effect.kernel.Resource
+
+import java.net.SocketAddress
+import java.net.SocketOption
+import java.nio.ByteBuffer
+import java.nio.channels.AsynchronousServerSocketChannel
+import java.nio.channels.AsynchronousSocketChannel
+import java.nio.channels.CompletionHandler
+
+import IOChannels._
+
+final class IOSocketChannel(ch: AsynchronousSocketChannel) {
+  def connect(remote: SocketAddress): IO[Unit] =
+    IO.async_[Void](cb => ch.connect(remote, null, toHandler(cb))).void
+
+  def read(dest: ByteBuffer): IO[Int] =
+    IO.async_[Integer](cb => ch.read(dest, null, toHandler(cb))).map(_.intValue)
+
+  def write(src: ByteBuffer): IO[Int] =
+    IO.async_[Integer](cb => ch.write(src, null, toHandler(cb))).map(_.intValue)
+
+  def shutdownInput: IO[Unit] = IO(ch.shutdownInput()).void
+
+  def shutdownOutput: IO[Unit] = IO(ch.shutdownOutput()).void
+
+  def setOption[T](option: SocketOption[T], value: T): IO[Unit] =
+    IO(ch.setOption(option, value)).void
+
+  def localAddress: IO[SocketAddress] =
+    IO(ch.getLocalAddress())
+
+  def remoteAddress: IO[SocketAddress] =
+    IO(ch.getRemoteAddress())
+}
+
+object IOSocketChannel {
+  def open: Resource[IO, IOSocketChannel] =
+    Resource.fromAutoCloseable(IO(AsynchronousSocketChannel.open())).map(new IOSocketChannel(_))
+}
+
+final class IOServerSocketChannel(ch: AsynchronousServerSocketChannel) {
+  def bind(local: SocketAddress): IO[Unit] =
+    IO(ch.bind(local)).void
+
+  def accept: Resource[IO, IOSocketChannel] =
+    Resource
+      .makeFull[IO, AsynchronousSocketChannel] { poll =>
+        poll {
+          IO.async { cb =>
+            IO(ch.accept(null, toHandler(cb)))
+              // it seems the only way to cancel accept is to close the socket :(
+              .as(Some(IO(ch.close())))
+          }
+        }
+      }(ch => IO(ch.close()))
+      .map(new IOSocketChannel(_))
+
+  def setOption[T](option: SocketOption[T], value: T): IO[Unit] =
+    IO(ch.setOption(option, value)).void
+
+  def localAddress: IO[SocketAddress] =
+    IO(ch.getLocalAddress())
+}
+
+object IOServerSocketChannel {
+  def open: Resource[IO, IOServerSocketChannel] =
+    Resource
+      .fromAutoCloseable(IO(AsynchronousServerSocketChannel.open()))
+      .map(new IOServerSocketChannel(_))
+}
+
+object IOChannels {
+  def toHandler[A](cb: Either[Throwable, A] => Unit): CompletionHandler[A, Any] =
+    new CompletionHandler[A, Any] {
+      def completed(result: A, attachment: Any): Unit = cb(Right(result))
+      def failed(exc: Throwable, attachment: Any): Unit = cb(Left(exc))
+    }
+}


### PR DESCRIPTION
This fixes an issue where `EpollApp`s were hanging upon the first async I/O op.

The problem was, unbeknownst to me, if you override the `runtime` in an `IOApp` it does not get installed as `IORuntime.global`. Because `EpollRuntime.global` was working in terms of `IORuntime.global`, this was causing two `EpollRuntime`s to be created, with I/O callbacks registered on the the second one not used by the `EpollApp`. Thus, the hang.

The fix is to just make the `EpollRuntime.global` completely independent of `IORuntime.global`. There is a bit of a footgun here, since two runtimes cannot coexist in a meaningful way, but I am following the Cats Effect design choice that an overridden runtime should not replace its own global runtime.

To explore this issue I created an example app and reorganized some of the test scaffolds. The example app is now run as part of the CI workflow.