### PR TITLE
Demo: do not use glue code for `accept4`

### DIFF
--- a/core/src/main/scala/epollcat/internal/ch/socket.scala
+++ b/core/src/main/scala/epollcat/internal/ch/socket.scala
@@ -26,7 +26,6 @@ private[ch] object socket {
   final val SOCK_NONBLOCK = 2048 // only in Linux and FreeBSD, but not macOS
 
   // only supported on Linux and FreeBSD, but not macOS
-  @name("epollcat_accept4")
   def accept4(sockfd: CInt, addr: Ptr[sockaddr], addrlen: Ptr[socklen_t], flags: CInt): CInt =
     extern
 }


### PR DESCRIPTION
@LeeTibbert  following up on https://github.com/armanbilge/epollcat/pull/50#discussion_r969632661. I removed the `@name` to delegate directly to the method without the glue code.

Fails locally with:
```
==> X epollcat.TcpSuite.local and remote addresses 0.01s munit.ComparisonFailException: /workspace/epollcat/tests/shared/src/test/scala/epollcat/TcpSuite.scala:119
118:                assertEquals(clientRemote, serverLocal)
119:                assertEquals(serverRemote, clientLocal)
120:              }
values are not the same
=> Obtained
/A00:D032:0:0:0:0:0:0:0
=> Diff (- obtained, + expected)
-/A00:D032:0:0:0:0:0:0:0
+/0:0:0:0:0:0:0:1:53298
```