### PR TITLE
Fix hang in `KqueueExecutorScheduler`

### DIFF
--- a/core/src/main/scala/epollcat/unsafe/KqueueExecutorScheduler.scala
+++ b/core/src/main/scala/epollcat/unsafe/KqueueExecutorScheduler.scala
@@ -65,53 +65,54 @@ private[unsafe] final class KqueueExecutorScheduler(
         }
       }
 
-      val timeoutSpec =
-        if (timeoutIsInfinite || timeoutIsZero) null
-        else {
-          val ts = stackalloc[time.timespec]()
-          val sec = timeout.toSeconds
-          ts.tv_sec = sec
-          ts.tv_nsec = (timeout - sec.seconds).toNanos
-          ts
-        }
-
-      val eventlist = stackalloc[kevent64_s](maxEvents.toLong)
-      val flags = (if (timeoutIsZero) KEVENT_FLAG_IMMEDIATE else KEVENT_FLAG_NONE).toUInt
-      val triggeredEvents =
-        kevent64(kqfd, changelist, finalChangeCount, eventlist, maxEvents, flags, timeoutSpec)
-
-      if (triggeredEvents >= 0) {
-        var i = 0
-        var event = eventlist
-        while (i < triggeredEvents) {
-          if ((event.flags.toLong & EV_ERROR) != 0) {
-
-            // TODO it would be interesting to propagate this failure via the callback
-            reportFailure(
-              new RuntimeException(
-                s"kevent64: flags=${event.flags.toHexString} errno=${event.data}"
-              )
-            )
-
-          } else if (callbacks.contains(event.ident.toLong)) {
-            val filter = event.filter
-            val cb = EventNotificationCallback.fromPtr(event.udata)
-
-            try {
-              cb.notifyEvents(filter == EVFILT_READ, filter == EVFILT_WRITE)
-            } catch {
-              case NonFatal(ex) =>
-                reportFailure(ex)
-            }
+      if (!noCallbacks) {
+        val timeoutSpec =
+          if (timeoutIsInfinite || timeoutIsZero) null
+          else {
+            val ts = stackalloc[time.timespec]()
+            val sec = timeout.toSeconds
+            ts.tv_sec = sec
+            ts.tv_nsec = (timeout - sec.seconds).toNanos
+            ts
           }
 
-          i += 1
-          event += 1
-        }
-      } else {
-        throw new RuntimeException(s"kevent64: ${errno.errno}")
-      }
+        val eventlist = stackalloc[kevent64_s](maxEvents.toLong)
+        val flags = (if (timeoutIsZero) KEVENT_FLAG_IMMEDIATE else KEVENT_FLAG_NONE).toUInt
+        val triggeredEvents =
+          kevent64(kqfd, changelist, finalChangeCount, eventlist, maxEvents, flags, timeoutSpec)
 
+        if (triggeredEvents >= 0) {
+          var i = 0
+          var event = eventlist
+          while (i < triggeredEvents) {
+            if ((event.flags.toLong & EV_ERROR) != 0) {
+
+              // TODO it would be interesting to propagate this failure via the callback
+              reportFailure(
+                new RuntimeException(
+                  s"kevent64: flags=${event.flags.toHexString} errno=${event.data}"
+                )
+              )
+
+            } else if (callbacks.contains(event.ident.toLong)) {
+              val filter = event.filter
+              val cb = EventNotificationCallback.fromPtr(event.udata)
+
+              try {
+                cb.notifyEvents(filter == EVFILT_READ, filter == EVFILT_WRITE)
+              } catch {
+                case NonFatal(ex) =>
+                  reportFailure(ex)
+              }
+            }
+
+            i += 1
+            event += 1
+          }
+        } else {
+          throw new RuntimeException(s"kevent64: ${errno.errno}")
+        }
+      }
       !changes.isEmpty() || callbacks.nonEmpty
     }
   }

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -242,4 +242,8 @@ class TcpSuite extends EpollcatSuite {
     IOSocketChannel.open.use_
   }
 
+  test("immediately closing a server socket does not hang") {
+    IOServerSocketChannel.open.use_
+  }
+
 }

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -238,4 +238,8 @@ class TcpSuite extends EpollcatSuite {
       .timeoutTo(100.millis, IO.unit)
   }
 
+  test("immediately closing a socket does not hang") {
+    IOSocketChannel.open.use_
+  }
+
 }

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -239,10 +239,12 @@ class TcpSuite extends EpollcatSuite {
   }
 
   test("immediately closing a socket does not hang") {
+    // note: on failure the test passes, but the test runner hangs
     IOSocketChannel.open.use_
   }
 
   test("immediately closing a server socket does not hang") {
+    // note: on failure the test passes, but the test runner hangs
     IOServerSocketChannel.open.use_
   }
 


### PR DESCRIPTION
Fix #64 
KqueueExecutorScheduler#poll no longer hangs when there is no work to do.
The fix was actually to check for the existence of callbacks, rather than of
new events.

Manually tested on macOS M1, Monterrey 12.6 with test-cond-in-development
for Issue #52.  I will be exercising this fix as I continue to work on Issue #52.


