### PR TITLE
Prevent `SIGPIPE` signals

### DIFF
--- a/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
+++ b/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
@@ -51,6 +51,7 @@ private[ch] object SocketHelpers {
       throw new RuntimeException(s"socket: ${errno.errno}")
 
     if (!LinktimeInfo.isLinux) setNonBlocking(fd)
+    if (LinktimeInfo.isMac) setNoSigPipe(fd)
 
     fd
   }
@@ -59,6 +60,10 @@ private[ch] object SocketHelpers {
     if (posix.fcntl.fcntl(fd, posix.fcntl.F_SETFL, posix.fcntl.O_NONBLOCK) != 0)
       throw new IOException(s"fcntl: ${errno.errno}")
     else ()
+
+  // macOS-only
+  def setNoSigPipe(fd: CInt): Unit =
+    setOption(fd, socket.SO_NOSIGPIPE, true)
 
   def setOption(fd: CInt, option: CInt, value: Boolean): Unit = {
     val ptr = stackalloc[CInt]()

--- a/core/src/main/scala/epollcat/internal/ch/socket.scala
+++ b/core/src/main/scala/epollcat/internal/ch/socket.scala
@@ -25,6 +25,12 @@ import scala.scalanative.posix.sys.socket._
 private[ch] object socket {
   final val SOCK_NONBLOCK = 2048 // only in Linux and FreeBSD, but not macOS
 
+  // only on Linux and FreeBSD, but not macOS
+  final val MSG_NOSIGNAL = 0x4000 /* Do not generate SIGPIPE */
+
+  // only on macOS and some BSDs (?)
+  final val SO_NOSIGPIPE = 0x1022 /* APPLE: No SIGPIPE on EPIPE */
+
   // only supported on Linux and FreeBSD, but not macOS
   @name("epollcat_accept4") // can remove glue code in SN 0.5
   def accept4(sockfd: CInt, addr: Ptr[sockaddr], addrlen: Ptr[socklen_t], flags: CInt): CInt =


### PR DESCRIPTION
More cross-platform mess 😩 . Fixes https://github.com/armanbilge/epollcat/issues/35.

I was unable to write a test, and based on the blog in https://github.com/armanbilge/epollcat/issues/35#issuecomment-1249966881 it seems writing such a test is very difficult. So I did not further waste my time on the matter.

Lee, thanks for putting me onto this issue, and I'm sorry that I didn't listen sooner!