### PR TITLE
Fix #52: Use IPv6 features only on IPv6 capable systems

### DIFF
--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
@@ -163,7 +163,7 @@ final class EpollAsyncServerSocketChannel private (fd: Int)
           if (!LinktimeInfo.isLinux)
             SocketHelpers.setNonBlocking(clientFd)
           val inetAddr =
-            if (SocketHelpers.preferIPv4Stack)
+            if (SocketHelpers.useIPv4Stack)
               SocketHelpers.toInet4SocketAddress(
                 addr.asInstanceOf[Ptr[posix.netinet.in.sockaddr_in]]
               )

--- a/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
+++ b/core/src/main/scala/epollcat/internal/ch/SocketHelpers.scala
@@ -30,8 +30,80 @@ import scala.scalanative.unsafe._
 
 private[ch] object SocketHelpers {
 
-  lazy val preferIPv4Stack =
-    java.lang.Boolean.parseBoolean(System.getProperty("java.net.preferIPv4Stack", "false"))
+  /* An approach with better software engineering becomes available
+   * when epollcat no longer supports Scala Native 0.4.n.
+   * One can eliminate the chance of races & mismatches by allocating a
+   * Scala Native socket and examining its address family. Scala Native
+   * will have done all the work.
+   *
+   * Tcp6Suite.scala uses a similar technique querying an
+   * AsynchronousServerSocketChannel.
+   */
+
+  lazy val useIPv4Stack = {
+    val systemPropertyForcesIPv4 =
+      java.lang.Boolean.parseBoolean(System.getProperty("java.net.preferIPv4Stack", "false"))
+    systemPropertyForcesIPv4 || hasOnlyIPv4Stack()
+  }
+
+  private def hasOnlyIPv4Stack(): Boolean = {
+    val addrinfo = stackalloc[Ptr[posix.netdb.addrinfo]]()
+    val hints = stackalloc[posix.netdb.addrinfo]()
+
+    hints.ai_family = posix.sys.socket.AF_INET6
+    hints.ai_flags = posix.netdb.AI_NUMERICHOST | posix.netdb.AI_NUMERICSERV
+    hints.ai_flags |= posix.netdb.AI_PASSIVE // ServerSocket
+    hints.ai_flags |= posix.netdb.AI_ADDRCONFIG
+    hints.ai_socktype = posix.sys.socket.SOCK_STREAM
+
+    val typelevelOrg6 = c"2606:50c0:8003::153"
+
+    val rtn = posix
+      .netdb
+      .getaddrinfo(
+        typelevelOrg6,
+        c"0",
+        hints,
+        addrinfo
+      )
+
+    val hasIPv6 =
+      try {
+        if (rtn == 0) {
+          // should never happen, but check anyways
+          java.util.Objects.requireNonNull(!addrinfo)
+          (!addrinfo).ai_family == posix.sys.socket.AF_INET6
+        } else {
+
+          if (rtn == posix.netdb.EAI_NONAME) { // expected on IPv4 & OK
+            false
+          } else if (rtn == posix.netdb.EAI_FAMILY) { // no IPv6 stack at all
+            false
+          } else {
+            val EAI_ADDRFAMILY =
+              if (LinktimeInfo.isLinux) -9
+              else if (LinktimeInfo.isFreeBSD) 1 // from FreeBSD source, untested
+              else {
+                // EAI_ADDRFAMILY is not defined on macOS & others.
+                // Force mismatch & allow throw, Exception has info we want to see.
+                0
+              }
+
+            if (rtn == EAI_ADDRFAMILY) {
+              false
+            } else {
+              val msg =
+                s"getaddrinfo: ${SocketHelpers.getGaiErrorMessage(rtn)}"
+              throw new IOException(msg)
+            }
+          }
+        }
+      } finally {
+        posix.netdb.freeaddrinfo(!addrinfo)
+      }
+
+    !hasIPv6
+  }
 
   def mkNonBlocking(): CInt = {
     val SOCK_NONBLOCK =
@@ -40,7 +112,7 @@ private[ch] object SocketHelpers {
       else 0
 
     val domain =
-      if (preferIPv4Stack)
+      if (useIPv4Stack)
         posix.sys.socket.AF_INET
       else
         posix.sys.socket.AF_INET6
@@ -117,7 +189,7 @@ private[ch] object SocketHelpers {
     !len = sizeof[posix.netinet.in.sockaddr_in6].toUInt
     if (posix.sys.socket.getsockname(fd, addr, len) == -1)
       throw new IOException(s"getsockname: ${errno.errno}")
-    if (preferIPv4Stack)
+    if (useIPv4Stack)
       toInet4SocketAddress(addr.asInstanceOf[Ptr[posix.netinet.in.sockaddr_in]])
     else
       toInet6SocketAddress(addr.asInstanceOf[Ptr[posix.netinet.in.sockaddr_in6]])
@@ -156,12 +228,12 @@ private[ch] object SocketHelpers {
       val addrinfo = stackalloc[Ptr[posix.netdb.addrinfo]]()
       val hints = stackalloc[posix.netdb.addrinfo]()
       hints.ai_family =
-        if (preferIPv4Stack)
+        if (useIPv4Stack)
           posix.sys.socket.AF_INET
         else
           posix.sys.socket.AF_INET6
       hints.ai_flags = posix.netdb.AI_NUMERICHOST | posix.netdb.AI_NUMERICSERV
-      if (!preferIPv4Stack) hints.ai_flags |= posix.netdb.AI_V4MAPPED
+      if (!useIPv4Stack) hints.ai_flags |= posix.netdb.AI_V4MAPPED
       hints.ai_socktype = posix.sys.socket.SOCK_STREAM
       val rtn = posix
         .netdb

--- a/tests/shared/src/test/scala/epollcat/Tcp6Suite.scala
+++ b/tests/shared/src/test/scala/epollcat/Tcp6Suite.scala
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package epollcat
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import java.net.Inet6Address
+import java.net.InetSocketAddress
+import java.net.StandardSocketOptions
+import java.net.BindException
+import java.nio.ByteBuffer
+import java.nio.channels.UnsupportedAddressTypeException
+import java.nio.channels.AsynchronousServerSocketChannel
+import java.nio.charset.StandardCharsets
+
+import scala.concurrent.duration._
+
+/* To manually monitor server connections on Linux: $netstat -tlpe -c
+ *  -l is listen (server) -c is continuous
+ */
+
+object NetworkProtocolInfo {
+
+  def epollcatUsesIPv4(): Boolean = {
+    val ch = AsynchronousServerSocketChannel.open
+
+    val haveIPv6 =
+      try {
+        ch.bind(new InetSocketAddress("::0", 0))
+
+        val nAddrBytes =
+          ch.getLocalAddress.asInstanceOf[InetSocketAddress].getAddress().getAddress().size
+
+        nAddrBytes == 16
+      } catch {
+        /*  The exact Exception thrown can and does differ by
+         *  operating system ^& IP protocol. They are all Exceptions.
+         *    EAI_ADDRFAMILY, is thrown on linux, freeBSD. It is not POSIX,
+         *       and the constant is different on each. Catch the
+         *       IOException they have in common.
+         *    BindException is defined, and tends to happen on macOS
+         */
+        case e: BindException => throw e // Apple and ??
+        case e: java.io.IOException => false // expected on Linux IPv4
+        // _Everything else is unexpected so let it bubble up.
+      } finally {
+        ch.close()
+      }
+
+    !haveIPv6
+  }
+
+}
+
+/*  Futures:
+ *    The ordering of output seems to be indeterminant.
+ *    That is, the output from a given test does not always
+ *    appear directly below/after its Suite.  It can look
+ *    like the Test belongs in another Suite.
+ *    Naming tests can give a clue that the real work is being done
+ *    and by whom, but the interleaving is, IMO, a defect.
+ */
+
+class Tcp6NotPresentSuite extends EpollcatSuite {
+  override def munitIOTimeout = 10.seconds
+
+  override def munitIgnore: Boolean =
+    NetworkProtocolInfo.epollcatUsesIPv4() == false
+
+  test("Bind ::1 - No IPv6") {
+
+    /* Linux, macOS, and possibly others use different message text.
+     * Test for an Exception occuring, but not for exact text.
+     * Avoiding Scala Native LinktimeInfo allows same test to run on both
+     * Scala Native and JVM. Very helpful.
+     */
+
+    /* Testing for an Exception is ugly, brutal, and effective.
+     * It is hard to peel away enough layers of abstraction to determine
+     * the underlying IP address_family/protocol.
+     */
+
+    IOServerSocketChannel
+      .open
+      .evalTap(_.setOption(StandardSocketOptions.SO_REUSEADDR, java.lang.Boolean.TRUE))
+      .use { ch =>
+        for {
+          _ <- ch.bind(new InetSocketAddress("::1", 0))
+        } yield ()
+      }
+      .intercept[java.io.IOException]
+  }
+}
+
+class Tcp6Suite extends EpollcatSuite {
+
+  /* 2022-09-12
+   *      The IPv6 wildcard address must be explicitly given to
+   *      InetSocketAddress on SN 0.4.n, fixed in 0.5.0-SNAPSHOT.
+   *         NO: serverCh.bind(new InetSocketAddress(0))
+   *         Yes: serverCh.bind(new InetSocketAddress("::", 0))
+   *       Tcp6Suite found a good one!
+   */
+
+  override def munitIOTimeout = 20.seconds
+
+  override def munitIgnore: Boolean = NetworkProtocolInfo.epollcatUsesIPv4()
+
+  def decode(bb: ByteBuffer): String =
+    StandardCharsets.UTF_8.decode(bb).toString()
+
+  // Checking IPv6 wildcard usage in default situations needs extra scrutiny.
+  test("Bind :: - IPv6 wildcard") {
+    IOServerSocketChannel
+      .open
+      .evalTap(_.setOption(StandardSocketOptions.SO_REUSEADDR, java.lang.Boolean.TRUE))
+      .use { ch =>
+        for {
+          // On Scala Native 0.4.n InetSocketAddress(0) will use IPv4, WRONG!
+          isa <- IO(new InetSocketAddress("::", 0))
+          _ <- IO(assert(clue(isa.getAddress.isInstanceOf[Inet6Address])))
+          _ <- ch.bind(isa)
+        } yield ()
+      }
+  }
+
+  test("Bind ::1") {
+    IOServerSocketChannel
+      .open
+      .evalTap(_.setOption(StandardSocketOptions.SO_REUSEADDR, java.lang.Boolean.TRUE))
+      .use { ch =>
+        for {
+          _ <- ch.bind(new InetSocketAddress("::1", 0))
+        } yield ()
+      }
+  }
+
+  test("Bind ip6-localhost") {
+    IOServerSocketChannel
+      .open
+      .evalTap(_.setOption(StandardSocketOptions.SO_REUSEADDR, java.lang.Boolean.TRUE))
+      .use { ch =>
+        for {
+          _ <- ch.bind(new InetSocketAddress("ip6-localhost", 0))
+        } yield ()
+      }
+  }
+
+  // Manually verified with netstat that IPv6 wildcard is being used on wire.
+  test("server-client ping-pong ::0 IPv6") {
+    (
+      IOServerSocketChannel
+        .open
+        .evalTap(_.setOption(StandardSocketOptions.SO_REUSEADDR, java.lang.Boolean.TRUE)),
+      IOSocketChannel.open
+    ).tupled.use {
+      case (serverCh, clientCh) =>
+        val server = serverCh.accept.use { ch =>
+          for {
+            lclAddr <- serverCh.localAddress
+            bb <- IO(ByteBuffer.allocate(4))
+            readed <- ch.read(bb)
+            _ <- IO(assertEquals(readed, 4))
+            res <- IO(bb.position(0)) *> IO(decode(bb))
+            _ <- IO(assertEquals(res, "ping"))
+            wrote <- ch.write(ByteBuffer.wrap("pong".getBytes))
+            _ <- IO(assertEquals(wrote, 4))
+          } yield ()
+        }
+
+        val client = for {
+          serverAddr <- serverCh.localAddress
+          _ <- clientCh.connect(serverAddr)
+          clientLocalAddr <- clientCh.localAddress
+          _ <- IO(
+            assert(clue(clientLocalAddr.asInstanceOf[InetSocketAddress].getPort()) != 0)
+          )
+          bb <- IO(ByteBuffer.wrap("ping".getBytes))
+          wrote <- clientCh.write(bb)
+          _ <- IO(assertEquals(bb.remaining(), 0))
+          _ <- IO(assertEquals(wrote, 4))
+          bb <- IO(ByteBuffer.allocate(4))
+          readed <- clientCh.read(bb)
+          _ <- IO(assertEquals(readed, 4))
+          _ <- IO(assertEquals(bb.remaining(), 0))
+          res <- IO(bb.position(0)) *> IO(decode(bb))
+          _ <- IO(assertEquals(res, "pong"))
+        } yield ()
+
+        serverCh.bind(new InetSocketAddress("::", 0)) *> server.both(client).void
+    }
+  }
+
+  test("local and remote addresses ::1") {
+    IOServerSocketChannel
+      .open
+      .evalTap(_.bind(new InetSocketAddress("::1", 0)))
+      .evalTap(_.setOption(StandardSocketOptions.SO_REUSEADDR, java.lang.Boolean.TRUE))
+      .use { server =>
+        IOSocketChannel.open.use { clientCh =>
+          server.localAddress.flatMap(clientCh.connect(_)) *>
+            server.accept.use { serverCh =>
+              for {
+                _ <- serverCh.shutdownOutput
+                _ <- clientCh.shutdownOutput
+                serverLocal <- serverCh.localAddress
+                serverRemote <- serverCh.remoteAddress
+                clientLocal <- clientCh.localAddress
+                clientRemote <- clientCh.remoteAddress
+              } yield {
+                assertEquals(clientRemote, serverLocal)
+                assertEquals(serverRemote, clientLocal)
+              }
+            }
+        }
+      }
+  }
+
+  test("local and remote addresses ip6-localhost") {
+    IOServerSocketChannel.open.evalTap(_.bind(new InetSocketAddress("ip6-localhost", 0))).use {
+      server =>
+        IOSocketChannel.open.use { clientCh =>
+          server.localAddress.flatMap(clientCh.connect(_)) *>
+            server.accept.use { serverCh =>
+              for {
+                _ <- serverCh.shutdownOutput
+                _ <- clientCh.shutdownOutput
+                serverLocal <- serverCh.localAddress
+                serverRemote <- serverCh.remoteAddress
+                clientLocal <- clientCh.localAddress
+                clientRemote <- clientCh.remoteAddress
+              } yield {
+                assertEquals(clientRemote, serverLocal)
+                assertEquals(serverRemote, clientLocal)
+              }
+            }
+        }
+    }
+  }
+
+  /* Operating systems differ as to whether binding to ::0 causes the server
+   * to listen on both ::0 and 127.0.0.1 or just the former. Linux listens
+   * on both. The BSDs tend to listen on just the former.
+   */
+
+  /*
+   * This test shows that listening on ::0 will indeed pick up a connection
+   * to another interface on the machine, not just the addressed passed as a
+   * variable in previous tests.
+   */
+  test("server-client ping-pong server ::0, client ::1") {
+    (
+      IOServerSocketChannel
+        .open
+        .evalTap(_.setOption(StandardSocketOptions.SO_REUSEADDR, java.lang.Boolean.TRUE)),
+      IOSocketChannel.open
+    ).tupled.use {
+      case (serverCh, clientCh) =>
+        val server = serverCh.accept.use { ch =>
+          for {
+            lclAddr <- serverCh.localAddress
+            bb <- IO(ByteBuffer.allocate(4))
+            readed <- ch.read(bb)
+            _ <- IO(assertEquals(readed, 4))
+            res <- IO(bb.position(0)) *> IO(decode(bb))
+            _ <- IO(assertEquals(res, "ping"))
+            wrote <- ch.write(ByteBuffer.wrap("pong".getBytes))
+            _ <- IO(assertEquals(wrote, 4))
+          } yield ()
+        }
+
+        val client = for {
+          serverLocalAddr <- serverCh.localAddress
+          port <- IO(serverLocalAddr.asInstanceOf[InetSocketAddress].getPort)
+          dstAddr <- IO(new InetSocketAddress("::1", port))
+          _ <- clientCh.connect(dstAddr)
+          clientLocalAddr <- clientCh.localAddress
+          _ <- IO(
+            assert(clue(clientLocalAddr.asInstanceOf[InetSocketAddress].getPort()) != 0)
+          )
+          bb <- IO(ByteBuffer.wrap("ping".getBytes))
+          wrote <- clientCh.write(bb)
+          _ <- IO(assertEquals(bb.remaining(), 0))
+          _ <- IO(assertEquals(wrote, 4))
+          bb <- IO(ByteBuffer.allocate(4))
+          readed <- clientCh.read(bb)
+          _ <- IO(assertEquals(readed, 4))
+          _ <- IO(assertEquals(bb.remaining(), 0))
+          res <- IO(bb.position(0)) *> IO(decode(bb))
+          _ <- IO(assertEquals(res, "pong"))
+        } yield ()
+
+        serverCh.bind(new InetSocketAddress("::", 0)) *> server.both(client).void
+    }
+  }
+
+}

--- a/tests/shared/src/test/scala/epollcat/Tcp6Suite.scala
+++ b/tests/shared/src/test/scala/epollcat/Tcp6Suite.scala
@@ -149,17 +149,6 @@ class Tcp6Suite extends EpollcatSuite {
       }
   }
 
-  test("Bind ip6-localhost") {
-    IOServerSocketChannel
-      .open
-      .evalTap(_.setOption(StandardSocketOptions.SO_REUSEADDR, java.lang.Boolean.TRUE))
-      .use { ch =>
-        for {
-          _ <- ch.bind(new InetSocketAddress("ip6-localhost", 0))
-        } yield ()
-      }
-  }
-
   // Manually verified with netstat that IPv6 wildcard is being used on wire.
   test("server-client ping-pong ::0 IPv6") {
     (
@@ -227,28 +216,6 @@ class Tcp6Suite extends EpollcatSuite {
             }
         }
       }
-  }
-
-  test("local and remote addresses ip6-localhost") {
-    IOServerSocketChannel.open.evalTap(_.bind(new InetSocketAddress("ip6-localhost", 0))).use {
-      server =>
-        IOSocketChannel.open.use { clientCh =>
-          server.localAddress.flatMap(clientCh.connect(_)) *>
-            server.accept.use { serverCh =>
-              for {
-                _ <- serverCh.shutdownOutput
-                _ <- clientCh.shutdownOutput
-                serverLocal <- serverCh.localAddress
-                serverRemote <- serverCh.remoteAddress
-                clientLocal <- clientCh.localAddress
-                clientRemote <- clientCh.remoteAddress
-              } yield {
-                assertEquals(clientRemote, serverLocal)
-                assertEquals(serverRemote, clientLocal)
-              }
-            }
-        }
-    }
   }
 
   /* Operating systems differ as to whether binding to ::0 causes the server

--- a/tests/shared/src/test/scala/epollcat/Tcp6Suite.scala
+++ b/tests/shared/src/test/scala/epollcat/Tcp6Suite.scala
@@ -55,7 +55,7 @@ object NetworkProtocolInfo {
          *    BindException is defined, and tends to happen on macOS
          */
         case e: BindException => throw e // Apple and ??
-        case e: java.io.IOException => false // expected on Linux IPv4
+        case _: java.io.IOException => false // expected on Linux IPv4
         // _Everything else is unexpected so let it bubble up.
       } finally {
         ch.close()
@@ -171,7 +171,6 @@ class Tcp6Suite extends EpollcatSuite {
       case (serverCh, clientCh) =>
         val server = serverCh.accept.use { ch =>
           for {
-            lclAddr <- serverCh.localAddress
             bb <- IO(ByteBuffer.allocate(4))
             readed <- ch.read(bb)
             _ <- IO(assertEquals(readed, 4))

--- a/tests/shared/src/test/scala/epollcat/Tcp6Suite.scala
+++ b/tests/shared/src/test/scala/epollcat/Tcp6Suite.scala
@@ -24,7 +24,6 @@ import java.net.InetSocketAddress
 import java.net.StandardSocketOptions
 import java.net.BindException
 import java.nio.ByteBuffer
-import java.nio.channels.UnsupportedAddressTypeException
 import java.nio.channels.AsynchronousServerSocketChannel
 import java.nio.charset.StandardCharsets
 

--- a/tests/shared/src/test/scala/epollcat/Tcp6Suite.scala
+++ b/tests/shared/src/test/scala/epollcat/Tcp6Suite.scala
@@ -271,7 +271,6 @@ class Tcp6Suite extends EpollcatSuite {
       case (serverCh, clientCh) =>
         val server = serverCh.accept.use { ch =>
           for {
-            lclAddr <- serverCh.localAddress
             bb <- IO(ByteBuffer.allocate(4))
             readed <- ch.read(bb)
             _ <- IO(assertEquals(readed, 4))

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -27,7 +27,21 @@ import java.net.StandardSocketOptions
 import java.nio.ByteBuffer
 import java.nio.channels.ClosedChannelException
 import java.nio.charset.StandardCharsets
+
 import scala.concurrent.duration._
+
+/* This file should be agnostic or blind to the underlying
+ * TCP protocol: IPv4 or IPv6. It should neither know nor care about
+ * the implementation protocol.
+ *
+ * Protocol specific testing should occur in related separate files.
+ */
+
+/* IPv4 testing should take place on systems running only IPv4.
+ * This is because of the way Scala Native handles the system property
+ * "java.net.preferIPv4Stack" interacts poorly with nameservers
+ * possibly being configured to returning IPv6 addresses before IPv4 ones,
+ */
 
 class TcpSuite extends EpollcatSuite {
 


### PR DESCRIPTION
Fix Issue #52.

epollcat now checks if a system is IPv6 capable when the executable starts.

IPv6 tests are run only on IPv6 capable systems.

IPv4 JVM tests can be run by "sbt '-J-Djava.net.preferIPv4Stack=true".

There is no easy way to pass "-Dmumble" to Scala Native. An application
must set that system property before the first socket call.  It is by
far easier to run the tests on an IPv4-only system.

  