### PR TITLE
Fix test output interleaving

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,7 @@ lazy val tests = crossProject(JVMPlatform, NativePlatform)
   .enablePlugins(NoPublishPlugin)
   .nativeConfigure(_.dependsOn(core))
   .settings(
+    Test / testOptions += Tests.Argument("+l"),
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect" % catsEffectVersion,
       "org.typelevel" %%% "munit-cats-effect" % munitCEVersion % Test


### PR DESCRIPTION
I think this fixes the problem noted here:

https://github.com/armanbilge/epollcat/blob/0128e88fd2e4323d2212920ab97a411feee020ce/tests/shared/src/test/scala/epollcat/Tcp6Suite.scala#L69-L76

This is annoying but with only a couple test suites I had been ignoring the issue. Fortunately your comment reminded me of https://github.com/scala-js/scala-js-macrotask-executor/commit/2179a6caa7b0162c88c3f1893a0a9a1a4f991c25.

I test this locally and indeed it seems to have improved the situation.