### PR TITLE
Fix #92: Special case connecting to wildcard on macOS

### DIFF
--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -222,16 +222,19 @@ class TcpSuite extends EpollcatSuite {
       // because the socket fd was pre-allocated as IPv6.
       .use { server =>
         IOSocketChannel.open.use { clientCh =>
-          if (true) { // IPv6 connect
-            server.localAddress.flatMap(clientCh.connect(_))
-          } else { // IPv4 connect
-            server
-              .localAddress
-              .flatMap(addr =>
-                clientCh.connect(
-                  new InetSocketAddress("0.0.0.0", addr.asInstanceOf[InetSocketAddress].getPort)
-                ))
-          }
+          // IPv6 connect()
+          server.localAddress.flatMap(clientCh.connect(_))
+
+          /* For a guaranteed IPv4 connection, comment previous source line out
+           * and un-comment this block.  Useful for manual testing:
+           *  server
+           *    .localAddress
+           *    .flatMap(addr =>
+           *      clientCh.connect(
+           *        new InetSocketAddress("0.0.0.0",
+           *                addr.asInstanceOf[InetSocketAddress].getPort)
+           *      ))
+           */
         }
       }
   }

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -210,24 +210,28 @@ class TcpSuite extends EpollcatSuite {
   }
 
   /* Listening to a wildcard is common practice.
-   * 'connecting' to a wildcard address is passing strange.
+   * "connect()'ing" to a wildcard address is passing strange.
    * See epollcat Issue #92 for details.
    */
-  test("bind to IPv4 wildcard and connect") {
+  test("bind to IPv4 wildcard then connect") {
     IOServerSocketChannel
       .open
+      .evalTap(_.setOption(StandardSocketOptions.SO_REUSEADDR, java.lang.Boolean.TRUE))
       .evalTap(_.bind(new InetSocketAddress("0.0.0.0", 0)))
       // If IPv6 active, IPv4 "0.0.0.0" will have been converted to IPv6 "::0"
       // because the socket fd was pre-allocated as IPv6.
-      .evalTap(_.localAddress.flatTap(IO.println))
       .use { server =>
-        // Active code will give an IPv6 connection.
-        // For an IPv4 connection, use commented out code.
         IOSocketChannel.open.use { clientCh =>
-          // addr => clientCh.connect(new
-          // InetSocketAddress(
-          // "0.0.0.0", addr.asInstanceOf[InetSocketAddress].getPort)))
-          server.localAddress.flatMap(clientCh.connect(_))
+          if (true) { // IPv6 connect
+            server.localAddress.flatMap(clientCh.connect(_))
+          } else { // IPv4 connect
+            server
+              .localAddress
+              .flatMap(addr =>
+                clientCh.connect(
+                  new InetSocketAddress("0.0.0.0", addr.asInstanceOf[InetSocketAddress].getPort)
+                ))
+          }
         }
       }
   }


### PR DESCRIPTION
Fix #92 

Arman supplied the test case; I am supplying a proposed fix & the bugs.

The details behind the fix is pretty complicated, so I will add it to Issue #92.  

TL; DR;    Cause macOS to do what Linux does, convert ::0 to ::1 when connecting.

I welcome improvements to the naming, format, and, especially, the actual Scala.