### PR TITLE
Fix #63: Server bind(null) becomes JVM bind(wildcard)

### DIFF
--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
@@ -69,7 +69,15 @@ final class EpollAsyncServerSocketChannel private (fd: Int)
   @stub
   def getOption[T](name: SocketOption[T]): T = ???
 
-  def bind(local: SocketAddress, backlog: Int): AsynchronousServerSocketChannel = {
+  def bind(localArg: SocketAddress, backlog: Int): AsynchronousServerSocketChannel = {
+
+    /* JVM defacto practice of null becoming wildcard.
+     *  on IPv6 systems, 0.0.0.0 will get converted to ::0.
+     */
+    val local =
+      if (localArg != null) localArg
+      else new InetSocketAddress("0.0.0.0", 0)
+
     val addrinfo = SocketHelpers.toAddrinfo(local.asInstanceOf[InetSocketAddress]) match {
       case Left(ex) => throw ex
       case Right(addrinfo) => addrinfo


### PR DESCRIPTION
Epollcat `EpollAsyncServerSocketChannel#bind` now follows the JVM practice of using the 
IP wildcard address when bind is given a null argument.  The spec says "pick one", JVM implementations
I tried  all picked the wildcard.

The IPv4 wildcard will work with IPv4 only systems. It will also work on an IPv6 system with the default
configuration of a server listening on both IPv6 & IPv4 wildcard addresses.
