### PR TITLE
Default `SO_REUSEADDR=true` for server socket

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ lazy val tests = crossProject(JVMPlatform, NativePlatform)
       "org.typelevel" %%% "munit-cats-effect" % munitCEVersion % Test
     )
   )
+  .jvmSettings(fork := true)
 
 lazy val example = project
   .in(file("example"))

--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncServerSocketChannel.scala
@@ -211,6 +211,7 @@ object EpollAsyncServerSocketChannel {
       case epoll: EventPollingExecutorScheduler =>
         val fd = SocketHelpers.mkNonBlocking()
         val ch = new EpollAsyncServerSocketChannel(fd)
+        ch.setOption(StandardSocketOptions.SO_REUSEADDR, java.lang.Boolean.TRUE)
         ch.unmonitor = epoll.monitor(fd, reads = true, writes = false)(ch)
         ch
       case _ =>

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -312,13 +312,18 @@ class TcpSuite extends EpollcatSuite {
   }
 
   test("closing/re-opening a server does not throw BindException: Address already in use") {
-    val address = new InetSocketAddress("127.0.0.0", 8080)
-    IOServerSocketChannel.open.evalTap(_.bind(address)).use { server =>
-      val connect =
-        IOSocketChannel.open.evalTap(_.connect(address)).surround(IO.sleep(1.second))
-      val accept = server.accept.surround(IO.sleep(1.second))
-      connect.both(accept).void
-    } *> IOServerSocketChannel.open.evalTap(_.bind(address)).use_
+    IOServerSocketChannel
+      .open
+      .evalTap(_.bind(new InetSocketAddress("localhost", 0)))
+      .use { server =>
+        server.localAddress.flatTap { address =>
+          val connect =
+            IOSocketChannel.open.evalTap(_.connect(address)).surround(IO.sleep(1.second))
+          val accept = server.accept.surround(IO.sleep(1.second))
+          connect.both(accept).void
+        }
+      }
+      .flatMap(address => IOServerSocketChannel.open.evalTap(_.bind(address)).use_)
   }
 
 }

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -311,4 +311,14 @@ class TcpSuite extends EpollcatSuite {
     IOServerSocketChannel.open.use_
   }
 
+  test("closing/re-opening a server does not throw BindException: Address already in use") {
+    val address = new InetSocketAddress("127.0.0.0", 8080)
+    IOServerSocketChannel.open.evalTap(_.bind(address)).use { server =>
+      val connect =
+        IOSocketChannel.open.evalTap(_.connect(address)).surround(IO.sleep(1.second))
+      val accept = server.accept.surround(IO.sleep(1.second))
+      connect.both(accept).void
+    } *> IOServerSocketChannel.open.evalTap(_.bind(address)).use_
+  }
+
 }


### PR DESCRIPTION
This seems to match the default for JDK 17 on Linux and macOS. Closes https://github.com/armanbilge/epollcat/issues/112.