### PR TITLE
Ignore `ENOTCONN` on socket shutdown

### DIFF
--- a/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
+++ b/core/src/main/scala/epollcat/internal/ch/EpollAsyncSocketChannel.scala
@@ -38,6 +38,7 @@ import scala.scalanative.annotation.stub
 import scala.scalanative.libc.errno
 import scala.scalanative.meta.LinktimeInfo
 import scala.scalanative.posix
+import scala.scalanative.posix.errno._
 import scala.scalanative.posix.netdbOps._
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
@@ -79,14 +80,14 @@ final class EpollAsyncSocketChannel private (
   def isOpen = _isOpen
 
   def shutdownInput(): AsynchronousSocketChannel = {
-    if (posix.sys.socket.shutdown(fd, 0) == -1)
+    if (posix.sys.socket.shutdown(fd, 0) == -1 && errno.errno != ENOTCONN)
       throw new IOException(s"shutdown: ${errno.errno}")
     this
   }
 
   def shutdownOutput(): AsynchronousSocketChannel = {
     outputShutdown = true
-    if (posix.sys.socket.shutdown(fd, 1) == -1)
+    if (posix.sys.socket.shutdown(fd, 1) == -1 && errno.errno != ENOTCONN)
       throw new IOException(s"shutdown: ${errno.errno}")
     this
   }

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -362,4 +362,22 @@ class TcpSuite extends EpollcatSuite {
       .flatMap(address => IOServerSocketChannel.open.evalTap(_.bind(address)).use_)
   }
 
+  test("shutdown ignores ENOTCONN".only) {
+    IOServerSocketChannel
+      .open
+      .evalTap(_.bind(new InetSocketAddress("localhost", 0)))
+      .use { server =>
+        server.localAddress.flatTap { address =>
+          val connect =
+            IOSocketChannel.open.evalTap(_.connect(address)).surround(IO.sleep(100.millis))
+          val accept = server.accept.use { ch =>
+            ch.write(ByteBuffer.wrap("hello".getBytes)) *>
+              IO.sleep(1.second) *> ch.shutdownInput *> ch.shutdownOutput
+          }
+          connect.both(accept).void
+        }
+      }
+      .flatMap(address => IOServerSocketChannel.open.evalTap(_.bind(address)).use_)
+  }
+
 }

--- a/tests/shared/src/test/scala/epollcat/TcpSuite.scala
+++ b/tests/shared/src/test/scala/epollcat/TcpSuite.scala
@@ -362,7 +362,7 @@ class TcpSuite extends EpollcatSuite {
       .flatMap(address => IOServerSocketChannel.open.evalTap(_.bind(address)).use_)
   }
 
-  test("shutdown ignores ENOTCONN".only) {
+  test("shutdown ignores ENOTCONN") {
     IOServerSocketChannel
       .open
       .evalTap(_.bind(new InetSocketAddress("localhost", 0)))


### PR DESCRIPTION
This matches the JDK behavior.

https://bugs.openjdk.org/browse/JDK-4516760

https://github.com/openjdk/jdk/blob/dcd6e756718b656d43f4575558f41ce0c28d0eca/src/java.base/unix/native/libnio/ch/Net.c#L844-L851